### PR TITLE
Add -k flag to kill delisted heartbeats

### DIFF
--- a/bin/hipcheck
+++ b/bin/hipcheck
@@ -45,6 +45,8 @@ program
     "Disk location where to cache. Flag.")
   .option('-f, --delete-cache',
     "Delete cache (reset cached hosts). Flag.")
+  .option('-k, --kill-delisted',
+    "Remove delisted hosts to avoid excessive error responses from bad hosts. Flag.")
   .option('-e, --rollbar <s>',
     "Rollbar token for error tracking. Default: undefined");
 

--- a/lib/Hipcheck.js
+++ b/lib/Hipcheck.js
@@ -23,7 +23,8 @@ function HipCheck (options) {
     redis         : '127.0.0.1:6379',
     cachePath     : path.join(process.env.HOME, '.hipcheck'),
     deleteCache   : false,
-    noCache       : false
+    noCache       : false,
+    killDelisted  : false
   });
 
   options.timeout *= 1000;

--- a/lib/VhostChecker.js
+++ b/lib/VhostChecker.js
@@ -130,6 +130,13 @@ VhostChecker.prototype.handleLatestHosts = function (latestHosts) {
   newHosts.forEach(function (host) {
     self.createHeartbeatFor(host);
   });
+
+  if (this.options.killDelisted) {
+    delistedHosts.forEach(function (host) {
+        self.removeHeartbeatFor(host);
+    });
+  }
+
   removedHosts.forEach(function (host) {
     self.removeHeartbeatFor(host);
   });


### PR DESCRIPTION
In the case that the user does not wish to keep pinging delisted urls.
